### PR TITLE
Create Company, User, JobAd, UserJobAd models to DB #7

### DIFF
--- a/migrations/20231014204054-create-company.js
+++ b/migrations/20231014204054-create-company.js
@@ -1,0 +1,34 @@
+'use strict';
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('Companies', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      name: {
+        type: Sequelize.STRING
+      },
+      country: {
+        type: Sequelize.STRING
+      },
+      location: {
+        type: Sequelize.STRING
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('Companies');
+  }
+};

--- a/migrations/20231014204534-create-job-ad.js
+++ b/migrations/20231014204534-create-job-ad.js
@@ -1,0 +1,45 @@
+'use strict';
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('JobAds', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      position: {
+        type: Sequelize.STRING
+      },
+      companyId: {
+        type: Sequelize.INTEGER,
+        references: {
+          model: 'Companies',
+          key: 'id',
+        },
+        allowNull: false,
+      },
+      reward: {
+        type: Sequelize.INTEGER
+      },
+      content: {
+        type: Sequelize.STRING
+      },
+      skills: {
+        type: Sequelize.STRING
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('JobAds');
+  }
+};

--- a/migrations/20231014210019-create-user.js
+++ b/migrations/20231014210019-create-user.js
@@ -1,0 +1,25 @@
+'use strict';
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('Users', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('Users');
+  }
+};

--- a/migrations/20231014212413-create-user-job-ad.js
+++ b/migrations/20231014212413-create-user-job-ad.js
@@ -1,0 +1,38 @@
+'use strict';
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('UserJobAds', {
+      userId: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        references: {
+          model: 'Users',
+          key: 'id'
+        }
+      },
+      jobAdId: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        references: {
+          model: 'JobAds',
+          key: 'id'
+        }
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+    await queryInterface.addIndex('UserJobAds', ['userId', 'jobAdId'], {
+      unique: true
+    });
+  },
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('UserJobAds');
+  }
+};

--- a/models/company.js
+++ b/models/company.js
@@ -1,0 +1,25 @@
+'use strict';
+const {
+  Model
+} = require('sequelize');
+module.exports = (sequelize, DataTypes) => {
+  class Company extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      // define association here
+    }
+  }
+  Company.init({
+    name: DataTypes.STRING,
+    country: DataTypes.STRING,
+    location: DataTypes.STRING
+  }, {
+    sequelize,
+    modelName: 'Company',
+  });
+  return Company;
+};

--- a/models/jobad.js
+++ b/models/jobad.js
@@ -1,0 +1,27 @@
+'use strict';
+const {
+  Model
+} = require('sequelize');
+module.exports = (sequelize, DataTypes) => {
+  class JobAd extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      this.belongsToMany(models.User, { through: 'UserJobAd', foreignKey: 'jobAdId' });
+    }
+  }
+  JobAd.init({
+    position: DataTypes.STRING,
+    companyId: DataTypes.INTEGER,
+    reward: DataTypes.INTEGER,
+    content: DataTypes.STRING,
+    skills: DataTypes.STRING
+  }, {
+    sequelize,
+    modelName: 'JobAd',
+  });
+  return JobAd;
+};

--- a/models/user.js
+++ b/models/user.js
@@ -1,0 +1,22 @@
+'use strict';
+const {
+  Model
+} = require('sequelize');
+module.exports = (sequelize, DataTypes) => {
+  class User extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      this.belongsToMany(models.JobAd, { through: 'UserJobAd', foreignKey: 'userId' });
+    }
+  }
+  User.init({
+  }, {
+    sequelize,
+    modelName: 'User',
+  });
+  return User;
+};

--- a/models/userjobad.js
+++ b/models/userjobad.js
@@ -1,0 +1,24 @@
+'use strict';
+const {
+  Model
+} = require('sequelize');
+module.exports = (sequelize, DataTypes) => {
+  class UserJobAd extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      // define association here
+    }
+  }
+  UserJobAd.init({
+    userId: DataTypes.INTEGER,
+    jobAdId: DataTypes.INTEGER
+  }, {
+    sequelize,
+    modelName: 'UserJobAd',
+  });
+  return UserJobAd;
+};


### PR DESCRIPTION
Changelog
====
- Create `Company`, `User`, `JobAd`, `UserJobAd` models to DB
  - `Company`: a model for companies. It contains fields such as `name`, `country`, `location` for each company. 
  - `User`: a model for users. It doesn't contains any fields.
  - `JobAd`: a model for job ads. It contains fields such as `position`, `companyId`, `reward`, `content`, `skills` for each job ad. `companyId` is a foreign key which references `id` of `Companies` table.
  - `UserJobAd`: a model for job ads which users applied for. It contains fields such as `userId`, `jobAdId` for each application. This is a bridge table which connects the `Users` and `JobAds` tables. It has a constraint that no same (userId, jobAdId) can be added repeatedly.