### PR TITLE
Introduce /jobad, /jobad/:id API endpoints #9

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,11 +1,139 @@
 const express = require('express');
+const { Company, JobAd } = require('./models'); // Sequelize model import
+
 const app = express();
-const PORT = 3000;
+
+app.use(express.json());
 
 app.get('/', (req, res) => {
     res.send('Hello World!');
 });
 
+app.get('/jobad', async (req, res) => {
+    try {
+        const jobAds = await JobAd.findAll();
+        res.json(jobAds);
+    } catch (error) {
+        res.status(500).send({ message: error.message });
+    }
+});
+
+app.post('/jobad', async (req, res) => {
+    try {
+        const {
+            companyId,
+            position,
+            reward,
+            content,
+            skills,
+            companyName,
+            companyLocation,
+            companyCountry
+        } = req.body;
+
+        // companyId에 해당하는 레코드가 Companies 테이블에 있는지 확인하고 없으면 생성
+        const [company, created] = await Company.findOrCreate({
+            where: { id: companyId },
+            defaults: {
+                name: companyName,
+                location: companyLocation,
+                country: companyCountry
+            }
+        });
+
+        const newJob = await JobAd.create({
+            companyId: company.id, // 여기서 생성된 또는 조회된 companyId를 사용
+            position,
+            reward,
+            content,
+            skills
+        });
+
+        // Created a new job ad
+        res.status(201).json(newJob);
+
+    } catch (error) {
+        res.status(500).json({ error: error.message });
+    }
+});
+
+app.put('/jobad/:id', async (req, res) => {
+    try {
+        const { id } = req.params;
+        const data = req.body;
+
+        const result = await JobAd.update(data, {
+            where: { id }
+        });
+
+        if (result[0] === 0) {
+            return res.status(404).send({ message: 'No record found to update' });
+        }
+
+        res.status(204).send();
+
+    } catch (error) {
+        res.status(500).send({ message: error.message });
+    }
+});
+
+app.delete('/jobad/:id', async (req, res) => {
+    try {
+        const { id } = req.params;
+
+        const result = await JobAd.destroy({
+            where: { id }
+        });
+
+        if (result === 0) {
+            return res.status(404).send({ message: 'No record found to delete' });
+        }
+
+        res.status(204).send();
+
+    } catch (error) {
+        res.status(500).send({ message: error.message });
+    }
+});
+
+app.get('/jobad/:id', async (req, res) => {
+    try {
+        const { id } = req.params;
+
+        const jobAd = await JobAd.findOne({
+            where: { id },
+            attributes: ['id', 'position', 'reward', 'skills', 'content'],
+            include: [{
+                model: Company,
+                attributes: ['name', 'location', 'country']
+            }]
+        });
+
+        if (!jobAd) {
+            return res.status(404).send({ message: 'No JobAd record found' });
+        }
+
+        const jobAdsCompanyHas = await JobAd.findAll({
+            where: { companyId: id },
+            attributes: ['id']
+        });
+
+        const jobAdIds = jobAdsCompanyHas.map(ad => ad.id);
+
+        const result = {
+            ...jobAd.dataValues,
+            ...jobAd.Company.dataValues,
+            OtherJobAdIds: jobAdIds
+        };
+
+        res.send(result);
+
+    } catch (error) {
+        res.status(500).send({ message: error.message });
+    }
+});
+
+const PORT = 3000;
 app.listen(PORT, '0.0.0.0', () => {
     console.log(`Server is running at http://0.0.0.0:${PORT}`);
 });

--- a/models/company.js
+++ b/models/company.js
@@ -10,7 +10,7 @@ module.exports = (sequelize, DataTypes) => {
      * The `models/index` file will call this method automatically.
      */
     static associate(models) {
-      // define association here
+      this.hasMany(models.JobAd, { foreignKey: 'companyId' });
     }
   }
   Company.init({

--- a/models/jobad.js
+++ b/models/jobad.js
@@ -10,6 +10,7 @@ module.exports = (sequelize, DataTypes) => {
      * The `models/index` file will call this method automatically.
      */
     static associate(models) {
+      this.belongsTo(models.Company, { foreignKey: 'companyId' });
       this.belongsToMany(models.User, { through: 'UserJobAd', foreignKey: 'jobAdId' });
     }
   }


### PR DESCRIPTION
Changelog
====
- introduces `/jobad` API endpoint for `GET`, `POST` methods.
  - `GET`: gets all the records in the `JobAd` model.
  - `POST`: posts a record into the `JobAd` model. creates a new record for a given company info if it doesn't exist in the `Company` model.
-  introduces `/jobad/:id` API endpoint for `GET`, `PUT`, `DELETE` methods
  - `GET`: gets a detailed info for a given job ad id. It also gets a detailed info for a given company id, and all the job ad ids this company has.
  - `PUT`: updates a specified record in the `JobAd` model into a given record.
  - `DELETE`: deletes a specified record in the `JobAd` model.
- defines association between the `JobAd` & `Company` models. It is to get the detailed info about the job ad for a given id easily.