### PR TITLE
Introduce .dockerignore to the repo #11

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+*.sqlite

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       dockerfile: Dockerfile
     ports:
       - "3000:3000"
+    volumes:
+      - ./db.development.sqlite:/usr/src/app/db.development.sqlite
 
   nginx:
     image: nginx:latest


### PR DESCRIPTION
Changelog
====
- introduce .dockerignore to the repo. It contains `*.sqlite` and `node_modules/`, since they don't need to be copied into the docker container.